### PR TITLE
fix(clap)!: Improve errors on `--color`

### DIFF
--- a/crates/clap/Cargo.toml
+++ b/crates/clap/Cargo.toml
@@ -22,4 +22,4 @@ api_unstable = ["concolor/api_unstable"]
 
 [dependencies]
 concolor = { version = "^0.0.8", path = "../concolor", default-features = false }
-clap = { version = "3.0", default-features = false, features = ["std", "derive"] }
+clap = { version = "3.0.10", default-features = false, features = ["std", "derive"] }

--- a/crates/clap/src/lib.rs
+++ b/crates/clap/src/lib.rs
@@ -30,7 +30,7 @@ pub fn color_choice() -> clap::ColorChoice {
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, clap::Args)]
 pub struct Color {
     /// Controls when to use color.
-    #[clap(long, default_value = "auto", value_name = "WHEN")]
+    #[clap(long, default_value_t = ColorChoice::Auto, value_name = "WHEN", arg_enum)]
     pub color: ColorChoice,
 }
 
@@ -52,31 +52,11 @@ impl Color {
 }
 
 /// Argument value for when to color output
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ArgEnum)]
 pub enum ColorChoice {
     Auto,
     Always,
     Never,
-}
-
-impl ColorChoice {
-    /// All color choices
-    pub const fn choices() -> &'static [Self] {
-        &[ColorChoice::Auto, ColorChoice::Always, ColorChoice::Never]
-    }
-
-    /// All color choice argument values
-    pub const fn values() -> &'static [&'static str] {
-        &[AUTO, ALWAYS, NEVER]
-    }
-
-    pub const fn value(self) -> &'static str {
-        match self {
-            Self::Auto => AUTO,
-            Self::Always => ALWAYS,
-            Self::Never => NEVER,
-        }
-    }
 }
 
 impl Default for ColorChoice {
@@ -85,9 +65,13 @@ impl Default for ColorChoice {
     }
 }
 
-impl core::fmt::Display for ColorChoice {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.value().fmt(f)
+impl std::fmt::Display for ColorChoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use clap::ArgEnum;
+        self.to_possible_value()
+            .expect("no values are skipped")
+            .get_name()
+            .fmt(f)
     }
 }
 


### PR DESCRIPTION
We didn't tell clap about the finite set of values.