### PR TITLE
The doc-test fails when the api_unstable feature isn't present.

### DIFF
--- a/crates/concolor/src/lib.rs
+++ b/crates/concolor/src/lib.rs
@@ -30,6 +30,7 @@
 //! If you are providing a command line option for controlling color, just call
 //! ```rust
 //! let when = concolor::ColorChoice::Always;
+//! #[cfg(feature = "api_unstable")]
 //! concolor::set(when);
 //! ```
 //!


### PR DESCRIPTION
concolor::set is part of api_unstable, so mark the doc-test accordingly.

Closes: #4