### PR TITLE
Ensure license files are included in packaged crates

### DIFF
--- a/crates/clap/LICENSE-APACHE
+++ b/crates/clap/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/clap/LICENSE-MIT
+++ b/crates/clap/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/concolor/LICENSE-APACHE
+++ b/crates/concolor/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/concolor/LICENSE-MIT
+++ b/crates/concolor/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/example/LICENSE-APACHE
+++ b/crates/example/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/example/LICENSE-MIT
+++ b/crates/example/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/query/LICENSE-APACHE
+++ b/crates/query/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/query/LICENSE-MIT
+++ b/crates/query/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT


### PR DESCRIPTION
Currently the packaged crates don't include the license text; this is specifically an issue for MIT as the license requires it.