### PR TITLE
chore: replace atty with is-terminal

### DIFF
--- a/crates/concolor/Cargo.toml
+++ b/crates/concolor/Cargo.toml
@@ -22,7 +22,7 @@ std = []
 core = ["std", "bitflags"]
 # Cross-crate API control is not guaranteed until our 1.0 release
 api_unstable = ["core"]
-interactive = ["core", "atty"]
+interactive = ["core", "dep:is-terminal"]
 clicolor = ["core", "concolor-query"]
 no_color = ["core", "concolor-query"]
 term = ["core", "concolor-query"]
@@ -34,4 +34,4 @@ features = ["auto", "api_unstable"]
 [dependencies]
 concolor-query = { version = "^0.1.0", path = "../query", optional = true }
 bitflags = { version = "1", optional = true }
-atty = { version = "0.2.14", optional = true }
+is-terminal = { version = "0.4", optional = true }

--- a/crates/concolor/src/color/mod.rs
+++ b/crates/concolor/src/color/mod.rs
@@ -111,10 +111,12 @@ fn init() -> usize {
 
     #[cfg(feature = "interactive")]
     {
-        if atty::is(atty::Stream::Stdout) {
+        use is_terminal::IsTerminal;
+        use std::io::{stderr, stdout};
+        if stdout().is_terminal() {
             flags |= InternalFlags::TTY_STDOUT;
         }
-        if atty::is(atty::Stream::Stderr) {
+        if stderr().is_terminal() {
             flags |= InternalFlags::TTY_STDERR;
         }
     }


### PR DESCRIPTION
`atty` is unmaintained and has a potential unaligned read. See https://github.com/rustsec/advisory-db/blob/main/crates/atty/RUSTSEC-2021-0145.md.

`is-terminal` is a replacement based on `atty`, with the soundness issue fixed and an (IMO) nicer to use API, mirroring what's available in the std lib on nightly with `std::io::IsTerminal`.

This is a follow-up on https://github.com/clap-rs/clap/pull/4249, to finish replacing `atty` in the context of `clap`.
