### PR TITLE
Enable color by default if 'interactive' or 'term' features are disabled

### DIFF
--- a/crates/concolor/src/color/mod.rs
+++ b/crates/concolor/src/color/mod.rs
@@ -108,6 +108,11 @@ fn init() -> usize {
             flags |= InternalFlags::TRUECOLOR;
         }
     }
+    #[cfg(not(feature = "term"))]
+    {
+        // Default to assuming the terminal supports color (or the user doesn't care)
+        flags |= InternalFlags::TERM_SUPPORT;
+    }
 
     #[cfg(feature = "interactive")]
     {
@@ -120,10 +125,22 @@ fn init() -> usize {
             flags |= InternalFlags::TTY_STDERR;
         }
     }
+    #[cfg(not(feature = "interactive"))]
+    {
+        // Default to assuming the stream is interactive (or the user doesn't care)
+        flags |= InternalFlags::TTY_STDOUT;
+        flags |= InternalFlags::TTY_STDERR;
+    }
 
     #[cfg(feature = "windows")]
     if concolor_query::windows::enable_ansi_colors().unwrap_or(false) {
         flags |= InternalFlags::ANSI_WIN;
+    }
+
+    #[cfg(not(any(feature = "term", feature = "windows")))]
+    {
+        // Default to assuming the terminal supports ANSI (or the user doesn't care)
+        flags |= InternalFlags::ANSI_SUPPORT;
     }
 
     flags.bits()


### PR DESCRIPTION
`concolor` defaults to color being disabled if `interactive` or `term` cargo features are disabled. It should default to being enabled, i.e. if the program author hasn't asked for `concolor` to check if the stream is interactive, then assume that it is, or the program author doesn't care and wants color anyway. Otherwise with these features disabled the only way to get colored output is using `CLICOLOR_FORCE`.